### PR TITLE
Add Kubernetes job definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,37 @@ kubectl run mqtt-load-generator --image=jforge/mqtt-load-generator  \
      -c 1000 -s 1000 -t /golang/pub -i 1 -n 100
 ```
 
+
+## Run as Kubernetes job
+
+To run as a Kubernetes job you can adjust the file `k8s/job.yaml` and apply it with:
+ 
+ ```bash
+ kubectl create -f k8s/job.yaml
+ ```
+
+To view the log output use: 
+```bash
+kubectl logs -f -l job-name=mqtt-load-generator
+```
+
+To restart when one run is finished you can use:
+```bash
+kubectl delete jobs.batch -l app=mqtt-load-generator ; kubectl create -f k8s/job.yaml
+```
+
+### Run multiple jobs parallel
+
+To run multiple jobs in parallel you adjust parameter `spec.parallelism` in `k8s/job.yaml`
+
+### Delete multiple jobs
+
+To clean up all mqtt-load-generator jobs you can run:
+```bash
+kubectl delete jobs.batch -l app=mqtt-load-generator
+```
+
+
 ## TODO
 
 - Use more idiomatic Go style

--- a/k8s/job.yaml
+++ b/k8s/job.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mqtt-load-generator
+  labels:
+    app: mqtt-load-generator
+spec:
+  completions: 1 # how many runs of the mqtt-load-generator do you want to run
+  parallelism: 1 # how many should run in parallel
+  ttlSecondsAfterFinished: 1800 # how many seconds until the job is cleaned up
+  template:
+    metadata:
+      labels:
+        app: mqtt-load-generator
+    spec:
+      containers:
+      - name: mqtt-load-generator
+        image: pgschk/mqtt-load-generator:latest
+        args:
+        - -h
+        - mqtt # hostname of mqtt server
+        - -p
+        - "1883" # port of mqtt server
+        - -u
+        - secret # username
+        - -P
+        -  mega_secret # password
+        - -c
+        - "1000" # number of messages per client
+        - -s
+        - "1000" # size per message in byte
+        - -t
+        - /golang/pub # target topic to publish to
+        - -i
+        - "1" # interval between published messages in ms
+        - -n
+        - "100" # numer of parallel clients
+      restartPolicy: Never
+  backoffLimit: 5
+  


### PR DESCRIPTION
Add a Kubernetes Job example defintion as well as README instructions.

When you publish an official image somewhere you should replace the image used in the job.