### PR TITLE
Add log-friendly output alternative to checker and build checker for docker 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,16 @@ COPY go.sum /app
 
 RUN go mod download
 
-COPY cmd/load_generator/main.go /app
+COPY cmd/load_generator/main.go /app/load_generator/main.go
+COPY cmd/checker/main.go /app/checker/main.go
 COPY pkg/ /app/pkg
 
-RUN CGO_ENABLED=0 go build -o /mqtt-load-generator
+RUN CGO_ENABLED=0 go build -o /mqtt-load-generator load_generator/main.go && \
+  go build -o /checker checker/main.go
 
 FROM alpine:3
 
 COPY --from=builder /mqtt-load-generator /mqtt-load-generator
-
+COPY --from=builder /checker /checker
 WORKDIR /app
 ENTRYPOINT [ "/mqtt-load-generator" ]

--- a/README.md
+++ b/README.md
@@ -46,14 +46,25 @@ To create a docker image for the load generator:
 docker build -t mqtt-load-generator .
 ```
 
+### Running the load generator
+
 To run a docker container from it reuse the same command line like above with:
 
 ```bash
 docker run --rm -it mqtt-load-generator -c 1000 -s 1000 -t /golang/pub -i 1 -n 100 -u secret -P mega_secret -h localhost -p 1883 
 ```
 
-To run the image in a Kubernetes cluster
+### Running the checker
+
+```bash
+docker run --entrypoint /checker --rm -it mqtt-load-generator -t /golang/pub -u secret -P mega_secret -h localhost -p 1883 
+```
+
+## Run on Kubernetes
+Here are a few methods of running the image in a Kubernetes cluster
 (e.g., to creating the load nearer to cluster resources by using cluster-local addresses):
+
+### Running the load generator
 
 ```bash
 kubectl run mqtt-load-generator --image=jforge/mqtt-load-generator  \
@@ -61,9 +72,15 @@ kubectl run mqtt-load-generator --image=jforge/mqtt-load-generator  \
      -c 1000 -s 1000 -t /golang/pub -i 1 -n 100
 ```
 
+### Running the load checker
 
-## Run as Kubernetes job
+```bash
+kubectl run mqtt-load-checker --image=pgschk/mqtt-load-generator --command \
+  -- /checker -h <mqtt-broker-address> -p 1883 -u secret -P mega_secret \
+      -t /golang/pub --disable-bar
+```
 
+### Running the load generator as a Kubernetes Job
 To run as a Kubernetes job you can adjust the file `k8s/job.yaml` and apply it with:
  
  ```bash
@@ -80,17 +97,21 @@ To restart when one run is finished you can use:
 kubectl delete jobs.batch -l app=mqtt-load-generator ; kubectl create -f k8s/job.yaml
 ```
 
-### Run multiple jobs parallel
+**Run multiple jobs parallel**
 
 To run multiple jobs in parallel you adjust parameter `spec.parallelism` in `k8s/job.yaml`
 
-### Delete multiple jobs
+**Delete multiple jobs**
 
 To clean up all mqtt-load-generator jobs you can run:
 ```bash
 kubectl delete jobs.batch -l app=mqtt-load-generator
 ```
 
+### Running the load checker as Kubernetes Deployment
+ ```bash
+ kubectl create -f k8s/checker-deployment.yaml
+ ```
 
 ## TODO
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/paulbellamy/ratecounter v0.2.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
+github.com/paulbellamy/ratecounter v0.2.0 h1:2L/RhJq+HA8gBQImDXtLPrDXK5qAj6ozWVK/zFXVJGs=
+github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/k8s/checker-deployment.yaml
+++ b/k8s/checker-deployment.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mqtt-checker
+spec:
+  selector:
+    matchLabels:
+      app: mqtt-checker
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mqtt-checker
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+      - name: mqtt-checker
+        image: pgschk/mqtt-load-generator:latest
+        command:
+        - /checker
+        args:
+        - -h
+        -  mqtt # hostname of mqtt server
+        - -p
+        - "1883" # port of mqtt server
+        - -u
+        - secret # username
+        - -P
+        -  mega_secret # password
+        - -t
+        - /golang/pub # target topic to subscribe to
+        - --disable-bar # disable interactive bar


### PR DESCRIPTION
This change adds an alternative output mode to the checker that is log friendly. To activate it use the `--disable-bar` argument.

Additionally it adds the checker binary to the docker image, and adds instructions how to use it for docker and K8s.

Got bigger than I expected, should I split it?